### PR TITLE
Handling HeartbeatControlMessages as a list of messages

### DIFF
--- a/CSharp Samples/Streaming.WebSocket.Samples/WebSocketSample.cs
+++ b/CSharp Samples/Streaming.WebSocket.Samples/WebSocketSample.cs
@@ -372,8 +372,8 @@ namespace Streaming.WebSocket.Samples
 			{
 				case "_heartbeat":
 					// HeartBeat messages indicate that no new data is available. You do not need to do anything.
-					var heartBeatMessage = DecodeWebSocketMessagePayload<HeartbeatControlMessage>(webSocketMessage);
-					var referenceIdList = String.Join(",", heartBeatMessage.Heartbeats.Select(h => h.OriginatingReferenceId));
+					var heartBeatMessage = DecodeWebSocketMessagePayload<HeartbeatControlMessage[]>(webSocketMessage);
+					var referenceIdList = String.Join(",", heartBeatMessage.First().Heartbeats.Select(h => h.OriginatingReferenceId));
 					Console.WriteLine($"{webSocketMessage.MessageId}\tHeartBeat control message received for reference ids {referenceIdList}.");
 					break;
 				case "_resetsubscriptions":


### PR DESCRIPTION
Getting errors in the C# sample when handling heartbeats. This is because heartbeats should be handled as a list of HeartBeatControlMessage rather than a single HeatBeatControlMessage. The is not apparent out-of-the-box in the sample, because the sample subscribes to EURUSD which (almost) never receives heartbeats due to the update rate. But to observe the behavior, try to subscribe to something else such as a US stock when the US Stock market is closed.